### PR TITLE
Add skills-specific PR template and refresh bug report placeholder

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -60,7 +60,7 @@ body:
       description: Include your agent version and `ultralytics` version when relevant.
       placeholder: |
         Agent: Codex 1.2.3
-        ultralytics: 8.4.117
+        ultralytics: 8.4.119
 
   - type: textarea
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--
+Thank you 🙏 for contributing to the [Ultralytics](https://www.ultralytics.com/) agent skills 🚀! To help us review and merge your Pull Request (PR) quickly:
+
+1. Check existing PRs to make sure your change is not already in progress.
+2. Link the related issue if there is one.
+3. Describe what changed and why, and paste the agent prompt and response you used to verify the guidance where relevant.
+4. Sign the Ultralytics Contributor License Agreement (CLA) by commenting below:
+
+    I have read the CLA Document and I sign the CLA
+
+Skill content checklist:
+
+- SKILL.md frontmatter is `name` + `description` only, `name` matches the directory, and the body stays under 500 lines.
+- Descriptions say when to use the skill (trigger keywords), not what it does.
+- Package facts (arguments, defaults, weight names, export formats) are checked against the pinned `ultralytics` version in the README, and version-volatile facts live in the companion catalog files, not SKILL.md.
+- Skills defer to the installed version (`yolo checks`, `yolo cfg`, error messages) over their own tables.
+- `python .github/scripts/lint_skills.py` passes.
+
+See the ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing) for more details.
+-->


### PR DESCRIPTION
## 🛠️ Summary

This repo was bootstrapped from `ultralytics/template`, so PRs currently fall back to the generic org-wide PR template. This adds a template tailored to agent-skill contributions and refreshes the one stale placeholder in the issue forms.

## 📊 Changes

- New `.github/PULL_REQUEST_TEMPLATE.md`: CLA prompt plus a short skill-content checklist (frontmatter, trigger-based descriptions, version grounding against the pinned `ultralytics` release, defer-to-installed-version, `lint_skills.py`).
- `.github/ISSUE_TEMPLATE/bug-report.yml`: version placeholder bumped from 8.4.117 to the pinned 8.4.119.

Audited the rest of the template-derived files (`.gitignore`, `dependabot.yml`, `ci.yml`, `format.yml`, `cla.yml`, issue forms, READMEs, manifests) against `ultralytics/template`; they are already customized for this repo, so no further changes were needed.

## 🎯 Purpose

Give contributors repo-specific guidance at PR time so skill changes arrive with the checks reviewers actually apply.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Added a skills-specific pull request template and updated the bug report version placeholder to match `ultralytics` 8.4.119.

### 📊 Key Changes
- Added `.github/PULL_REQUEST_TEMPLATE.md` with:
  - CLA sign-off instructions and contribution checklist.
  - Guidance for skill frontmatter, trigger-based descriptions, and the 500-line body limit.
  - Checks for version-grounded package facts, installed-version precedence, and `lint_skills.py`.
- Updated the bug report form placeholder in `.github/ISSUE_TEMPLATE/bug-report.yml` from `ultralytics` 8.4.117 to 8.4.119.

### 🎯 Purpose & Impact
- New pull requests now receive repository-specific contribution guidance for agent skills.
- Bug reports now use the current pinned `ultralytics` version in their example data.