### PR TITLE
Remove trailing slashes and update redirected Ultralytics URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -15,5 +15,5 @@ contact_links:
     url: https://www.ultralytics.com/discord
     about: Ask on Ultralytics Discord
   - name: ⌨️ Reddit
-    url: https://reddit.com/r/ultralytics
+    url: https://www.reddit.com/r/ultralytics/
     about: Ask on Ultralytics Subreddit

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-Thank you 🙏 for contributing to the [Ultralytics](https://www.ultralytics.com/) agent skills 🚀! To help us review and merge your Pull Request (PR) quickly:
+Thank you 🙏 for contributing to the [Ultralytics](https://www.ultralytics.com) agent skills 🚀! To help us review and merge your Pull Request (PR) quickly:
 
 1. Check existing PRs to make sure your change is not already in progress.
 2. Link the related issue if there is one.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Agent skills for [Ultralytics Platform](https://platform.ultralytics.com), the [
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
-[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
+[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/ultralytics/)
 
 ## 🧩 Skills
 
@@ -25,7 +25,7 @@ Agent skills for [Ultralytics Platform](https://platform.ultralytics.com), the [
 | [`yolo-inference`](skills/yolo-inference/SKILL.md) | Platform Predict/endpoints, local predict, Results API, tracking, Solutions                          |
 | [`yolo-export`](skills/yolo-export/SKILL.md)       | Platform/local ONNX/TensorRT/CoreML/OpenVINO/LiteRT/NPU export, quantization, benchmarking           |
 
-Each skill is a `SKILL.md` (procedures, decision tables, gotchas) with Codex/ChatGPT presentation metadata, plus, where needed, a companion reference file holding version-volatile catalogs (weight names, argument tables, format matrix). Package facts are grounded against `ultralytics` v8.4.119; Platform flows are grounded against the current [Platform documentation](https://docs.ultralytics.com/platform/).
+Each skill is a `SKILL.md` (procedures, decision tables, gotchas) with Codex/ChatGPT presentation metadata, plus, where needed, a companion reference file holding version-volatile catalogs (weight names, argument tables, format matrix). Package facts are grounded against `ultralytics` v8.4.119; Platform flows are grounded against the current [Platform documentation](https://docs.ultralytics.com/platform).
 
 ## 📦 Install
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,7 +11,7 @@
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
-[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
+[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/ultralytics/)
 
 ## 🧩 Skills
 
@@ -25,7 +25,7 @@
 | [`yolo-inference`](skills/yolo-inference/SKILL.md) | Platform Predict/端点、本地推理、Results API、跟踪和 Solutions                              |
 | [`yolo-export`](skills/yolo-export/SKILL.md)       | Platform/本地 ONNX/TensorRT/CoreML/OpenVINO/LiteRT/NPU 导出、量化和基准测试                 |
 
-每个 Skill 都包含一个 `SKILL.md`（操作步骤、决策表和注意事项）以及 Codex/ChatGPT 展示元数据；必要时还会包含配套参考文件，用于保存随版本变化的目录信息（权重名称、参数表、导出格式矩阵）。软件包信息基于 `ultralytics` v8.4.119；Platform 流程基于当前的 [Platform 文档](https://docs.ultralytics.com/platform/)。
+每个 Skill 都包含一个 `SKILL.md`（操作步骤、决策表和注意事项）以及 Codex/ChatGPT 展示元数据；必要时还会包含配套参考文件，用于保存随版本变化的目录信息（权重名称、参数表、导出格式矩阵）。软件包信息基于 `ultralytics` v8.4.119；Platform 流程基于当前的 [Platform 文档](https://docs.ultralytics.com/platform)。
 
 ## 📦 安装
 

--- a/skills/yolo-datasets/SKILL.md
+++ b/skills/yolo-datasets/SKILL.md
@@ -27,8 +27,8 @@ The #1 cause of silent training failure is a malformed dataset — validate befo
 
 Platform datasets currently cover six tasks; depth dataset support is still pending.
 Smart Annotation is unavailable for connected cloud datasets. See
-[Platform Data](https://docs.ultralytics.com/platform/data/) and the
-[Annotation Editor](https://docs.ultralytics.com/platform/data/annotation/).
+[Platform Data](https://docs.ultralytics.com/platform/data) and the
+[Annotation Editor](https://docs.ultralytics.com/platform/data/annotation).
 
 To train on the same dataset from local code, create an API key under **Settings > API
 Keys**, set `ULTRALYTICS_API_KEY`, and use its URI directly:

--- a/skills/yolo-export/SKILL.md
+++ b/skills/yolo-export/SKILL.md
@@ -21,7 +21,7 @@ deployment target, just as with a local engine build.
 Use Platform when you do not want to install each exporter toolchain locally. Use the
 Python/CLI path below for custom calibration, repeatable automation, local hardware
 builds, or immediate parity validation. See
-[Platform model export](https://docs.ultralytics.com/platform/train/models/#export-model).
+[Platform model export](https://docs.ultralytics.com/platform/train/models#export-model).
 
 ## Quickstart
 

--- a/skills/yolo-inference/SKILL.md
+++ b/skills/yolo-inference/SKILL.md
@@ -35,8 +35,8 @@ print(response.json())
 ```
 
 Dedicated endpoints use scale-to-zero, so expect a cold start after idle periods. See
-[Platform Inference](https://docs.ultralytics.com/platform/deploy/inference/) and
-[Dedicated Endpoints](https://docs.ultralytics.com/platform/deploy/endpoints/).
+[Platform Inference](https://docs.ultralytics.com/platform/deploy/inference) and
+[Dedicated Endpoints](https://docs.ultralytics.com/platform/deploy/endpoints).
 
 ## Quickstart
 

--- a/skills/yolo-models/SKILL.md
+++ b/skills/yolo-models/SKILL.md
@@ -26,8 +26,8 @@ checkpoints for further fine-tuning.
 
 Use a Platform model page to inspect metrics, test it in **Predict**, export it, deploy it,
 clone it into another project, or download its `.pt` weights for the Python/CLI workflows
-below. See [Platform Models](https://docs.ultralytics.com/platform/train/models/) and
-[Explore](https://docs.ultralytics.com/platform/explore/).
+below. See [Platform Models](https://docs.ultralytics.com/platform/train/models) and
+[Explore](https://docs.ultralytics.com/platform/explore).
 
 ## Model = family + size + task suffix
 

--- a/skills/yolo-training/SKILL.md
+++ b/skills/yolo-training/SKILL.md
@@ -12,7 +12,7 @@ description: >
 
 ## Fastest route: train in Platform
 
-Use [Platform cloud training](https://docs.ultralytics.com/platform/train/cloud-training/)
+Use [Platform cloud training](https://docs.ultralytics.com/platform/train/cloud-training)
 when you want to start in a few clicks without configuring a local GPU:
 
 1. Create a project and click **New Model** (or start from a dataset's **Train** action).

--- a/skills/yolo-tuning/SKILL.md
+++ b/skills/yolo-tuning/SKILL.md
@@ -34,7 +34,7 @@ in the confusion matrix → nothing else matters until fixed.
 
 ## Compare experiments in Platform
 
-Keep candidates in one [Platform project](https://docs.ultralytics.com/platform/train/projects/).
+Keep candidates in one [Platform project](https://docs.ultralytics.com/platform/train/projects).
 Train from the **New Model** dialog, or stream local runs by setting
 `project=username/project-slug` and a unique `name`. Select models together in the
 project charts, or use **Table > Diff** to compare training arguments and final metrics.

--- a/skills/yolo/SKILL.md
+++ b/skills/yolo/SKILL.md
@@ -63,7 +63,7 @@ yolo export model=best.pt format=onnx                        # exported model lo
    epochs, then monitor the run.
 5. Use the completed model's **Predict**, **Export**, or **Deploy** tab.
 
-Start with the [Platform quickstart](https://docs.ultralytics.com/platform/quickstart/).
+Start with the [Platform quickstart](https://docs.ultralytics.com/platform/quickstart).
 Use the stage skill below for both Platform and package details.
 
 ## Route before coding


### PR DESCRIPTION
## Summary

Canonicalizes Ultralytics links across the repo: strips terminating path slashes from every `ultralytics.com` / `*.ultralytics.com` URL, and refreshes one externally redirected link.

## Changes

- **13 trailing slashes removed** across 10 files (`docs.ultralytics.com/platform*` deep links in the seven `SKILL.md` files, both READMEs, and `PULL_REQUEST_TEMPLATE.md`). Includes the pre-fragment case `.../train/models/#export-model` -> `.../train/models#export-model` and the bare-host case `https://www.ultralytics.com/` -> `https://www.ultralytics.com`.
- **1 redirect accepted** (3 occurrences): `https://reddit.com/r/ultralytics` -> `https://www.reddit.com/r/ultralytics/` (permanent host canonicalization; matches the badge form already used in the `ultralytics/ultralytics` README). Applied in `README.md`, `README.zh-CN.md`, and `.github/ISSUE_TEMPLATE/config.yml`.

Diff is URL text only — no prose, code, or manifest logic touched.

## Judgment calls

- **Rejected** `https://agentskills.io` -> `https://agentskills.io/home` (4 occurrences in `README.md`, `README.zh-CN.md`, `AGENTS.md`/`CLAUDE.md`). This is a client-side SPA route append, not a content move; the bare root is the durable link.
- **Kept** `"skills": "./skills/"` in `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` — that trailing slash is contractual and is asserted verbatim by `.github/scripts/lint_skills.py`.
- **Untouched** vanity shortlinks (`ultralytics.com/discord`, `ultralytics.com/bilibili`), the `ultralytics.com/license` header strings written by Ultralytics Actions, and the URL-encoded `server=https%3A%2F%2Fcommunity.ultralytics.com` shields.io badge parameter.

No dead links were detected in the scan.

## Validation

- All 11 rewritten `docs.ultralytics.com` / `www.ultralytics.com` targets re-checked serially: HTTP 200 with no redirect hop.
- `python .github/scripts/lint_skills.py` -> OK: 7 skills, 7 OpenAI metadata files, 4 manifests validated.
- `prettier@3.8.5 --print-width 120 --check` over all Markdown/YAML/JSON -> clean.
- Repo re-scanned after the edits: zero remaining terminating slashes on any Ultralytics URL.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Canonicalized Ultralytics documentation and Reddit URLs by removing unnecessary trailing slashes and updating Reddit links to the `www` host.

### 📊 Key Changes

- Removed trailing slashes from Platform documentation links across the seven skill files, both READMEs, and the pull request template, including the `#export-model` fragment link.
- Updated three Reddit links in `README.md`, `README.zh-CN.md`, and `.github/ISSUE_TEMPLATE/config.yml` to `https://www.reddit.com/r/ultralytics/`.
- Preserved contractual plugin paths, vanity shortlinks, generated license URLs, and the root `agentskills.io` links.
- The diff changes URL text only; no prose, code, or manifest logic was modified.

### 🎯 Purpose & Impact

- Documentation links now use canonical URL forms without redirecting trailing slashes, while Reddit links use the canonical `www.reddit.com` host.
- No user-facing change to documented workflows or repository logic.